### PR TITLE
Add SNES Core "agg23/openfpga-SNES"

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -69,5 +69,8 @@
     },
     {
         "repo": "opengateware/arcade-galaga"
+    },
+    {
+        "repo": "agg23/openfpga-SNES"
     }
 ]


### PR DESCRIPTION
Adds SNES Core at Repo https://github.com/agg23/openfpga-SNES